### PR TITLE
Не создавать пустые массивы при отсутствиии обработчиков

### DIFF
--- a/lib/no.events.js
+++ b/lib/no.events.js
@@ -98,13 +98,19 @@ no.Events.off = function(name, handler) {
 //  В каждый передаем name и params.
 //
 no.Events.trigger = function(name, params) {
-    //  Копируем список хэндлеров.
-    //  Если вдруг внутри какого-то обработчика будет вызван `off()`,
-    //  то мы не потеряем вызов следующего обработчика.
-    var handlers = this._noevents_get(name).slice();
 
-    for (var i = 0, l = handlers.length; i < l; i++) {
-        handlers[i].call(this, name, params);
+    // не используем ._noevents_get(), чтобы не создавать пустые массивы при отсутствии обработчиков события
+    var handlers = this._noevents_handlers && this._noevents_handlers[name];
+
+    if (handlers) {
+        //  Копируем список хэндлеров.
+        //  Если вдруг внутри какого-то обработчика будет вызван `off()`,
+        //  то мы не потеряем вызов следующего обработчика.
+        handlers = handlers.slice();
+    
+        for (var i = 0, l = handlers.length; i < l; i++) {
+            handlers[i].call(this, name, params);
+        }
     }
 };
 


### PR DESCRIPTION
Иначе, это замедляет лукап по объекту.
