### PR TITLE
Fix JS error while walk through null value in array

### DIFF
--- a/lib/no.jpath.js
+++ b/lib/no.jpath.js
@@ -989,7 +989,7 @@ function array_step( data, name, result ) {
         var item = data[ i ];
         if ( Array.isArray( item ) ) {
             array_step( item, name, result );
-        } else {
+        } else if (item) {
             var value = item[ name ];
             if ( value !== undefined ) {
                 result.push( value );

--- a/tests/no.jpath.js
+++ b/tests/no.jpath.js
@@ -430,7 +430,10 @@ describe('falsy jpaths', function() {
             e: 0,
             f: null,
             g: false,
-            h: undefined
+            h: undefined,
+            arr: [
+                { nullValue: null }
+            ]
         }
     };
 
@@ -468,6 +471,14 @@ describe('falsy jpaths', function() {
 
     it('non-existence key', function() {
         expect( no.jpath('.foo{ .z }.c', data) ).to.be(undefined);
+    });
+
+    it('walk through null value', function() {
+        expect( no.jpath('.foo.f.id', data) ).to.be(undefined);
+    });
+
+    it('walk through null value in array', function() {
+        expect( no.jpath('.foo.arr.nullValue.id', data) ).to.be.eql([]);
     });
 
 });


### PR DESCRIPTION
Case:
```
var data = {
   foo: [
     bar: null
   ]
}

no.jpath('.foo.bar.id', data);
```

Error:
```
TypeError: Cannot read property 'id' of null
      at array_step (lib/no.jpath.js:993:29)
      at e0 (eval at compile (lib/no.jpath.js:1136:20), <anonymous>:4:309)
      at Object.no.jpath (lib/no.jpath.js:31:34)
```

I'm not sure about return value `[]`. Validate it please